### PR TITLE
Add an MGL unit to the dataset

### DIFF
--- a/backend/src/parser/transformer.rs
+++ b/backend/src/parser/transformer.rs
@@ -10,10 +10,11 @@ pub struct Transformer {
 
 /// ```
 /// # use gbhwdb_backend::parser::parse_transformer;
+/// assert!(parse_transformer("82Y7").is_some());
 /// assert!(parse_transformer("84Z7").is_some());
 /// ```
 fn mitsumi() -> MatcherDef<Transformer> {
-    MatcherDef(r#"^(84Z7)$"#, move |c| {
+    MatcherDef(r#"^(82Y7|84Z7)$"#, move |c| {
         Ok(Transformer {
             kind: c[1].to_owned(),
             manufacturer: Some(Manufacturer::Mitsumi),

--- a/data/consoles/MGL/L10010466/01_front.jpg
+++ b/data/consoles/MGL/L10010466/01_front.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f4f0d9c6bcf9540877566d0fb5a195e1165353cd5f7a4683533e5054f20fbcc5
+size 579891

--- a/data/consoles/MGL/L10010466/02_back.jpg
+++ b/data/consoles/MGL/L10010466/02_back.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fae2d10ee8d4b79d0cc0fbcbcd527797b94d51be077dbb7f645e585b0add2b3a
+size 770675

--- a/data/consoles/MGL/L10010466/03_pcb_front.jpg
+++ b/data/consoles/MGL/L10010466/03_pcb_front.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1c46508dea66c97018d464baef7a1d6142a4c1ba05ce1e54d82dcddab85d4a29
+size 925959

--- a/data/consoles/MGL/L10010466/04_pcb_back.jpg
+++ b/data/consoles/MGL/L10010466/04_pcb_back.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:619ee3484281c36fee325f0c315bc789f9e2172185063e73e4e120c68877f25f
+size 971498

--- a/data/consoles/MGL/L10010466/metadata.json
+++ b/data/consoles/MGL/L10010466/metadata.json
@@ -1,0 +1,40 @@
+{
+  "slug": "L10010466",
+  "contributor": "ide",
+  "shell": {
+    "color": "Silver",
+    "release_code": "MGL-JPN",
+    "serial": "L10010466"
+  },
+  "mainboard": {
+    "label": "MGL-CPU-01",
+    "number_pair": "2-1",
+    "stamp": "128-3419",
+    "circled_letters": "I",
+    "year": 1998,
+    "u1": {
+      "label": "CPU MGB Ⓜ © 1996 Nintendo JAPAN 9810 DA"
+    },
+    "u2": {
+      "label": "LH5164AN-10L SHARP JAPAN 9805 7 EB"
+    },
+    "u3": {
+      "label": "AMP MGB IR3R53N 9809 a"
+    },
+    "u4": {
+      "label": "DMG-REG IR3E02 9809 n"
+    },
+    "x1": {
+      "label": "KDS 9805 4.194"
+    },
+    "t1": {
+      "label": "82Y7"
+    }
+  },
+  "screen": {
+    "row_driver": {
+      "label": "8070",
+      "ribbon_label": "LH5076E"
+    }
+  }
+}


### PR DESCRIPTION
This is an MGL console with one of the lower serial numbers. The chip numbers are also slightly different (lower numbers) than the other MGL unit.
    
To get the site generator to run I needed to add the Mitsumi transformer chip to the matcher.
    
I found the LCD's row driver but am not sure where the column driver is. I didn't want to displace the screen.
    
The screen's backing plate has the number 8213 stamped on it but I didn't list this as the screen's label since it is missing from the component database. Additionally, the LCD's ribbon cable has a numeric stamp on it (T80303) and a part number (M1085) but I didn't add those fields since they are not part of the schema.
    
Tested by building and running the site locally.